### PR TITLE
Update run.js

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -26,12 +26,12 @@ function getExecutableExtension() {
 function getkubectlDownloadURL(version) {
     switch (os.type()) {
         case 'Linux':
-            return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/linux/amd64/kubectl', version);
+            return util.format('https://storage.googleapis.com/kubernetes-release/release/v%s/bin/linux/amd64/kubectl', version);
         case 'Darwin':
-            return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/darwin/amd64/kubectl', version);
+            return util.format('https://storage.googleapis.com/kubernetes-release/release/v%s/bin/darwin/amd64/kubectl', version);
         case 'Windows_NT':
         default:
-            return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/windows/amd64/kubectl.exe', version);
+            return util.format('https://storage.googleapis.com/kubernetes-release/release/v%s/bin/windows/amd64/kubectl.exe', version);
     }
 }
 function getStableKubectlVersion() {


### PR DESCRIPTION
url for installing kubectl receives the semantic version string like "1.15.0" and it adds the letter 'v' before it. To not change the documentation, I believe this edit would solve it. 

What solved for me was was to use it like this:
```
- uses: azure/setup-kubectl@v1
        with:
          version: 'v1.15.0'
        id: install
```

But then I was not able to run kubectl commands... :/