### PR TITLE
Bump @actions/core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
          "version": "0.0.0",
          "license": "MIT",
          "dependencies": {
-            "@actions/core": "^1.9.1",
+            "@actions/core": "^1.10.0",
             "@actions/exec": "^1.0.0",
             "@actions/tool-cache": "^1.0.0"
          },
@@ -24,9 +24,9 @@
          }
       },
       "node_modules/@actions/core": {
-         "version": "1.9.1",
-         "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-         "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+         "version": "1.10.0",
+         "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+         "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
          "dependencies": {
             "@actions/http-client": "^2.0.1",
             "uuid": "^8.3.2"
@@ -6172,9 +6172,9 @@
    },
    "dependencies": {
       "@actions/core": {
-         "version": "1.9.1",
-         "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-         "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+         "version": "1.10.0",
+         "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+         "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
          "requires": {
             "@actions/http-client": "^2.0.1",
             "uuid": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
    "author": "GitHub",
    "license": "MIT",
    "dependencies": {
-      "@actions/core": "^1.9.1",
+      "@actions/core": "^1.10.0",
       "@actions/exec": "^1.0.0",
       "@actions/tool-cache": "^1.0.0"
    },


### PR DESCRIPTION
to address https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
