### PR TITLE
update build script to include ncc install

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
    "private": true,
    "main": "lib/index.js",
    "scripts": {
-      "build": "ncc build src/run.ts -o lib",
+      "build": "npm i ncc && npx ncc build src/run.ts -o lib",
       "test": "jest",
       "test-coverage": "jest --coverage",
       "format": "prettier --write .",


### PR DESCRIPTION
gh actions won't respect npx installed devdeps, so i added the install to the build script and called through npx