### PR TITLE
Security: remove updated action and fix prettier

### DIFF
--- a/.github/workflows/prettify-code.yml
+++ b/.github/workflows/prettify-code.yml
@@ -12,7 +12,14 @@ jobs:
          - name: Checkout Repository
            uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-         - name: Enforce Prettier
-           uses: actionsx/prettier@3d9f7c3fa44c9cb819e68292a328d7f4384be206 #v3.0.0
+         - name: Setup Node.js
+           uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
            with:
-              args: --check .
+              node-version: 'lts/*'
+              cache: 'npm'
+
+         - name: Install Dependencies
+           run: npm ci
+
+         - name: Run Prettier Check
+           run: npx prettier --check .


### PR DESCRIPTION
With reference to the below PR, updating the outdated actions - https://github.com/Azure/aks-set-context/pull/147

This PR also fixes the old issues with styling for this repo and now the whole repo will pass for the actual check for prettier.

This PR improves the Prettier check workflow by replacing the third-party actionsx/prettier action with a direct npx prettier --check command. It also:

Ensures faster builds via setup-node.
Uses npm ci for a cleaner and more consistent dependency installation.
This enhances transparency, flexibility, and performance in enforcing Prettier formatting.
