### PR TITLE
release 4.0.1 fix v prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [v4.0.0] - 2024-01-30
+## [4.0.1] - 2025-06-17
+
+- Remove erronious 'v' prefix on previous changelog for v4.0.0 that led to "vv4.0.0" tag issue
+- Dependabot fixes
+
+## [4.0.0] - 2024-01-30
 
 ### Changed
 


### PR DESCRIPTION
the changelog includes a `[v4.0.0]` entry that should have been `[4.0.0]`

this led to a release tagged `vv4.0.0`

this PR fixed the error, and releases v4.0.1 with the latest dependabot changes