### PR TITLE
Workflow run from comment to get format auto commit.

### DIFF
--- a/.github/workflows/format-from-comment.yml
+++ b/.github/workflows/format-from-comment.yml
@@ -1,0 +1,64 @@
+name: Format via PR Comment
+
+on:
+   issue_comment:
+      types: [created]
+
+permissions:
+   contents: write
+   pull-requests: write
+
+jobs:
+   format-on-comment:
+      if: >
+         github.event.issue.pull_request &&
+         startsWith(github.event.comment.body, '/format')
+      runs-on: ubuntu-latest
+      steps:
+         - name: Get PR Info
+           id: pr
+           uses: actions/github-script@v7
+           with:
+              script: |
+                 const pr = await github.rest.pulls.get({
+                   owner: context.repo.owner,
+                   repo: context.repo.repo,
+                   pull_number: context.payload.issue.number
+                 });
+
+                 core.setOutput("branch", pr.data.head.ref);
+                 core.setOutput("repo", pr.data.head.repo.full_name);
+                 core.setOutput("default_branch", pr.data.base.ref);
+
+         - name: Checkout PR branch
+           uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+           with:
+              repository: ${{ steps.pr.outputs.repo }}
+              ref: ${{ steps.pr.outputs.branch }}
+              token: ${{ secrets.GITHUB_TOKEN }}
+
+         - name: Set up Node.js
+           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+           with:
+              node-version: 20
+
+         - name: Install dependencies
+           run: npm ci
+
+         - name: Run Prettier format
+           run: npm run format
+
+         - name: Commit and push changes
+           run: |
+              git config user.name "${{ github.actor }}"
+              git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+              git add .
+
+              if git diff --cached --quiet; then
+                echo "✅ No formatting changes."
+              else
+                git commit -s -m "style: auto-format via /format comment"
+                git push origin HEAD:${{ steps.pr.outputs.branch }}
+                echo "✅ Formatting committed to PR branch."
+              fi

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,6 @@
 {
    "trailingComma": "none",
-   "bracketSpacing": false,
+   "bracketSpacing": true,
    "semi": false,
    "tabWidth": 3,
    "singleQuote": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
             "@types/node": "^24.0.2",
             "@vercel/ncc": "^0.38.3",
             "jest": "^30.0.0",
-            "prettier": "3.5.3",
+            "prettier": "^3.5.3",
             "ts-jest": "^29.4.0",
             "typescript": "5.8.3"
          }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
       "@types/node": "^24.0.2",
       "@vercel/ncc": "^0.38.3",
       "jest": "^30.0.0",
-      "prettier": "3.5.3",
+      "prettier": "^3.5.3",
       "ts-jest": "^29.4.0",
       "typescript": "5.8.3"
    }


### PR DESCRIPTION
This is for the case where users who are maintainers will be able to run the `prettier write` against a repo by simply calling this `/format` from the comment and it will auto add the commit for the format.

This is phase-1 in the second phase - we will add the husky pre-commit formatter as well, that will require some setting form the user but we can always hook for the repo as a script command run from the machine like `npm run setup-husky-pre-commit-check` 

Please don't worry about the current prettier issue it's because we surpassed one rule which I've enabled it again. = ) 

* Sample run here: https://github.com/Tatsinnit/setup-kubectl/pull/7 
* Sample workflow which adds the commit: https://github.com/Tatsinnit/setup-kubectl/actions/runs/15842557323/job/44657786483 

Thanks

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNnZ2MzVscHd1cmZmZGllbDhwbmU5M3ByaDdteWhkYTNvNTd4dDB3ZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Lqep8CZFH5xhJfKAUT/giphy.gif)