### PR TITLE
Update `stableVersionUrl` to dl.k8s.io

### DIFF
--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -251,7 +251,7 @@ describe('Testing all functions in run file.', () => {
       jest.spyOn(core, 'setOutput').mockImplementation()
       expect(await run.run()).toBeUndefined()
       expect(toolCache.downloadTool).toHaveBeenCalledWith(
-         'https://storage.googleapis.com/kubernetes-release/release/stable.txt'
+         'https://dl.k8s.io/release/stable.txt'
       )
       expect(core.getInput).toHaveBeenCalledWith('version', {required: true})
       expect(core.addPath).toHaveBeenCalledWith('pathToCachedTool')

--- a/src/run.ts
+++ b/src/run.ts
@@ -12,8 +12,7 @@ import {
 
 const kubectlToolName = 'kubectl'
 const stableKubectlVersion = 'v1.15.0'
-const stableVersionUrl =
-   'https://storage.googleapis.com/kubernetes-release/release/stable.txt'
+const stableVersionUrl = 'https://dl.k8s.io/release/stable.txt'
 
 export async function run() {
    let version = core.getInput('version', {required: true})

--- a/test/validate-kubectl.py
+++ b/test/validate-kubectl.py
@@ -10,7 +10,7 @@ def get_latest_version():
     time_to_sleep = 2
     for _ in range(10):
         response = requests.get(
-            'https://storage.googleapis.com/kubernetes-release/release/stable.txt')
+            'https://dl.k8s.io/release/stable.txt')
         if response.status_code == 200:
             break
         print('Failed to obtain latest version info, retrying.')


### PR DESCRIPTION
The `stableVersionUrl` currently relies on `gs://kubernetes-release`, but it is no longer updated. This PR updates to use `dl.k8s.io`.
Docs: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/
See: https://github.com/kubernetes/k8s.io/issues/2396

```console
$ curl -L https://storage.googleapis.com/kubernetes-release/release/stable.txt
v1.31.0
```
```console
$ curl -L https://dl.k8s.io/release/stable.txt
v1.34.0
```
