### PR TITLE
Description was inaccurate, should have v prefix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Kubectl tool installer'
-description: 'Install a specific version of kubectl binary. Acceptable values are latest or any semantic version string like 1.15.0'
+description: 'Install a specific version of kubectl binary. Acceptable values are latest or any semantic version string like "v1.15.0"'
 inputs:
    version:
       description: 'Version of kubectl'


### PR DESCRIPTION
Corrected instructions to indicate that a `v` prefix must be added to the input, which matches the readme.