### PR TITLE
fix: add node types to tsconfig for TypeScript 6 compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,10 @@
       "moduleResolution": "NodeNext",
       "rootDir": "./src",
       "outDir": "./lib",
+      "types": ["node"],
       "skipLibCheck": true,
       "noEmit": true
    },
+   "include": ["src"],
    "exclude": ["node_modules", "**/*.test.ts", "vitest.config.ts"]
 }


### PR DESCRIPTION
- add `types: ["node"]` to tsconfig compilerOptions
- add `include: ["src"]` to explicitly scope compilation
- TypeScript 6 no longer auto-resolves `@types/node` without explicit `types` config
- unblocks dependabot PR #250 (typescript 5.9.3 → 6.0.2)
- build and tests pass (30/30)