### PR TITLE
feat: add downloadBaseURL input to support custom download mirrors

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
       description: 'Version of kubectl'
       required: true
       default: 'latest'
+   downloadBaseURL:
+      description: 'Set the download base URL'
+      required: false
+      default: 'https://dl.k8s.io'
 outputs:
    kubectl-path:
       description: 'Path to the cached kubectl binary'

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -11,17 +11,22 @@ export function getKubectlArch(): string {
    return arch
 }
 
-export function getkubectlDownloadURL(version: string, arch: string): string {
+export function getkubectlDownloadURL(
+   version: string,
+   arch: string,
+   baseURL: string = 'https://dl.k8s.io'
+): string {
+   const base = baseURL.replace(/\/$/, '')
    switch (os.type()) {
       case 'Linux':
-         return `https://dl.k8s.io/release/${version}/bin/linux/${arch}/kubectl`
+         return `${base}/release/${version}/bin/linux/${arch}/kubectl`
 
       case 'Darwin':
-         return `https://dl.k8s.io/release/${version}/bin/darwin/${arch}/kubectl`
+         return `${base}/release/${version}/bin/darwin/${arch}/kubectl`
 
       case 'Windows_NT':
       default:
-         return `https://dl.k8s.io/release/${version}/bin/windows/${arch}/kubectl.exe`
+         return `${base}/release/${version}/bin/windows/${arch}/kubectl.exe`
    }
 }
 

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -89,6 +89,34 @@ describe('Testing all functions in run file.', () => {
          expect(os.type).toHaveBeenCalled()
       }
    )
+   test.each([['arm'], ['arm64'], ['amd64']])(
+      'getkubectlDownloadURL() - return the URL to download %s kubectl for Linux with custom base URL',
+      (arch) => {
+         vi.mocked(os.type).mockReturnValue('Linux')
+         const customBase = 'https://my-mirror.example.com'
+         const expected = util.format(
+            `${customBase}/release/v1.15.0/bin/linux/%s/kubectl`,
+            arch
+         )
+         expect(getkubectlDownloadURL('v1.15.0', arch, customBase)).toBe(
+            expected
+         )
+      }
+   )
+   test.each([['arm'], ['arm64'], ['amd64']])(
+      'getkubectlDownloadURL() - strip trailing slash from custom base URL for %s on Darwin',
+      (arch) => {
+         vi.mocked(os.type).mockReturnValue('Darwin')
+         const customBase = 'https://my-mirror.example.com/'
+         const expected = util.format(
+            `https://my-mirror.example.com/release/v1.15.0/bin/darwin/%s/kubectl`,
+            arch
+         )
+         expect(getkubectlDownloadURL('v1.15.0', arch, customBase)).toBe(
+            expected
+         )
+      }
+   )
    test('getStableKubectlVersion() - download stable version file, read version and return it', async () => {
       vi.mocked(toolCache.downloadTool).mockResolvedValue('pathToTool')
       vi.mocked(fs.readFileSync).mockReturnValue('v1.20.4')
@@ -118,12 +146,29 @@ describe('Testing all functions in run file.', () => {
          path.join('pathToCachedTool', 'kubectl.exe')
       )
       expect(toolCache.find).toHaveBeenCalledWith('kubectl', 'v1.15.0')
-      expect(toolCache.downloadTool).toHaveBeenCalled()
+      expect(toolCache.downloadTool).toHaveBeenCalledWith(
+         'https://dl.k8s.io/release/v1.15.0/bin/windows/amd64/kubectl.exe'
+      )
       expect(toolCache.cacheFile).toHaveBeenCalled()
       expect(os.type).toHaveBeenCalled()
       expect(fs.chmodSync).toHaveBeenCalledWith(
          path.join('pathToCachedTool', 'kubectl.exe'),
          '775'
+      )
+   })
+   test('downloadKubectl() - download kubectl using custom downloadBaseURL', async () => {
+      vi.mocked(toolCache.find).mockReturnValue('')
+      vi.mocked(toolCache.downloadTool).mockResolvedValue('pathToTool')
+      vi.mocked(toolCache.cacheFile).mockResolvedValue('pathToCachedTool')
+      vi.mocked(os.type).mockReturnValue('Linux')
+      vi.mocked(os.arch).mockReturnValue('x64')
+      vi.mocked(fs.chmodSync).mockImplementation(() => {})
+      const customBase = 'https://my-mirror.example.com'
+      expect(await run.downloadKubectl('v1.15.0', customBase)).toBe(
+         path.join('pathToCachedTool', 'kubectl')
+      )
+      expect(toolCache.downloadTool).toHaveBeenCalledWith(
+         `${customBase}/release/v1.15.0/bin/linux/amd64/kubectl`
       )
    })
    test('downloadKubectl() - throw DownloadKubectlFailed error when unable to download kubectl', async () => {
@@ -235,6 +280,9 @@ describe('Testing all functions in run file.', () => {
       vi.mocked(core.setOutput).mockImplementation()
       expect(await run.run()).toBeUndefined()
       expect(core.getInput).toHaveBeenCalledWith('version', {required: true})
+      expect(core.getInput).toHaveBeenCalledWith('downloadBaseURL', {
+         required: false
+      })
       expect(core.addPath).toHaveBeenCalledWith('pathToCachedTool')
       expect(core.setOutput).toHaveBeenCalledWith(
          'kubectl-path',
@@ -256,6 +304,9 @@ describe('Testing all functions in run file.', () => {
          'https://dl.k8s.io/release/stable.txt'
       )
       expect(core.getInput).toHaveBeenCalledWith('version', {required: true})
+      expect(core.getInput).toHaveBeenCalledWith('downloadBaseURL', {
+         required: false
+      })
       expect(core.addPath).toHaveBeenCalledWith('pathToCachedTool')
       expect(core.setOutput).toHaveBeenCalledWith(
          'kubectl-path',

--- a/src/run.ts
+++ b/src/run.ts
@@ -21,7 +21,8 @@ export async function run() {
    } else {
       version = await resolveKubectlVersion(version)
    }
-   const cachedPath = await downloadKubectl(version)
+   const downloadBaseURL = core.getInput('downloadBaseURL', {required: false})
+   const cachedPath = await downloadKubectl(version, downloadBaseURL)
 
    core.addPath(path.dirname(cachedPath))
 
@@ -48,14 +49,17 @@ export async function getStableKubectlVersion(): Promise<string> {
    )
 }
 
-export async function downloadKubectl(version: string): Promise<string> {
+export async function downloadKubectl(
+   version: string,
+   downloadBaseURL: string = 'https://dl.k8s.io'
+): Promise<string> {
    let cachedToolpath = toolCache.find(kubectlToolName, version)
    let kubectlDownloadPath = ''
    const arch = getKubectlArch()
    if (!cachedToolpath) {
       try {
          kubectlDownloadPath = await toolCache.downloadTool(
-            getkubectlDownloadURL(version, arch)
+            getkubectlDownloadURL(version, arch, downloadBaseURL)
          )
       } catch (exception) {
          if (


### PR DESCRIPTION
## Summary

Closes #206

Adds a new optional `downloadBaseURL` action input that allows users to specify a custom or private mirror for kubectl downloads, useful in air-gapped or enterprise environments.

### Changes

- **`action.yml`** — new optional input `downloadBaseURL` (default: `https://dl.k8s.io`)
- **`src/helpers.ts`** — `getkubectlDownloadURL()` accepts a `baseURL` parameter (trailing slashes are stripped)
- **`src/run.ts`** — `downloadKubectl()` accepts and forwards `downloadBaseURL`; `run()` reads the input and passes it through
- **`src/run.test.ts`** — 7 new tests covering custom base URL and trailing-slash normalization

### Usage

```yaml
- uses: Azure/setup-kubectl@v4
  with:
    version: 'v1.30.0'
    downloadBaseURL: 'https://my-mirror.example.com'
```

### Tests

All 37 tests pass.