### PR TITLE
feat: add downloadBaseURL and checksum inputs (closes #206)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -54,3 +54,32 @@ jobs:
 
          - name: Validate kubectl setup old version
            run: python test/validate-kubectl.py 'v1.15.1'
+
+         - name: Fetch known SHA256 for v1.30.0 linux/amd64
+           id: sha
+           run: |
+              value=$(curl -fsSL https://dl.k8s.io/release/v1.30.0/bin/linux/amd64/kubectl.sha256)
+              echo "value=$value" >> "$GITHUB_OUTPUT"
+
+         - name: Setup kubectl with valid checksum
+           uses: ./
+           with:
+              version: 'v1.30.0'
+              checksum: ${{ steps.sha.outputs.value }}
+
+         - name: Validate kubectl setup with checksum
+           run: python test/validate-kubectl.py 'v1.30.0'
+
+         - name: Setup kubectl with bad checksum (expect failure)
+           id: badsum
+           continue-on-error: true
+           uses: ./
+           with:
+              version: 'v1.29.0'
+              checksum: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+
+         - name: Assert bad-checksum step failed
+           if: steps.badsum.outcome != 'failure'
+           run: |
+              echo "Expected bad-checksum step to fail, but outcome was: ${{ steps.badsum.outcome }}"
+              exit 1

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,14 @@ inputs:
       description: 'Version of kubectl'
       required: true
       default: 'latest'
+   downloadBaseURL:
+      description: 'Base URL to download kubectl from (https only). Use for private mirrors.'
+      required: false
+      default: 'https://dl.k8s.io'
+   checksum:
+      description: 'Expected SHA256 of the kubectl binary. Recommended when overriding downloadBaseURL.'
+      required: false
+      default: ''
 outputs:
    kubectl-path:
       description: 'Path to the cached kubectl binary'

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
          "dependencies": {
             "@actions/core": "^3.0.1",
             "@actions/exec": "^3.0.0",
+            "@actions/http-client": "^4.0.0",
             "@actions/tool-cache": "^4.0.0"
          },
          "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
    "dependencies": {
       "@actions/core": "^3.0.1",
       "@actions/exec": "^3.0.0",
+      "@actions/http-client": "^4.0.0",
       "@actions/tool-cache": "^4.0.0"
    },
    "devDependencies": {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,8 +1,224 @@
 import * as os from 'os'
-import * as util from 'util'
 import * as fs from 'fs'
+import * as net from 'net'
+import * as path from 'path'
+import * as crypto from 'crypto'
 import * as core from '@actions/core'
 import * as toolCache from '@actions/tool-cache'
+import {HttpClient} from '@actions/http-client'
+
+export const DEFAULT_KUBECTL_BASE_URL = 'https://dl.k8s.io'
+
+export function normalizeBaseURL(input: string): string {
+   const u = new URL(input)
+   return `${u.protocol}//${u.host}${u.pathname.replace(/\/+$/, '')}`
+}
+
+export function isDefaultBaseURL(input: string): boolean {
+   try {
+      return (
+         normalizeBaseURL(input) === normalizeBaseURL(DEFAULT_KUBECTL_BASE_URL)
+      )
+   } catch {
+      return false
+   }
+}
+
+const SECURE_DOWNLOAD_MAX_BYTES = 256 * 1024 * 1024
+const SECURE_DOWNLOAD_MAX_REDIRECTS = 5
+
+export async function secureDownload(downloadURL: string): Promise<string> {
+   const client = new HttpClient('setup-kubectl', [], {
+      allowRedirects: false
+   })
+
+   let currentURL = downloadURL
+   let response
+   let status: number | undefined
+   for (let hop = 0; hop <= SECURE_DOWNLOAD_MAX_REDIRECTS; hop++) {
+      response = await client.get(currentURL)
+      status = response.message.statusCode
+
+      if (!status || status < 300 || status >= 400) break
+
+      const locationHeader = response.message.headers['location']
+      const location = Array.isArray(locationHeader)
+         ? locationHeader[0]
+         : locationHeader
+      response.message.resume()
+      if (!location) {
+         throw new Error(
+            `Redirect from custom downloadBaseURL had no Location header (status ${status}).`
+         )
+      }
+      if (hop === SECURE_DOWNLOAD_MAX_REDIRECTS) {
+         throw new Error(
+            `Refusing download: exceeded ${SECURE_DOWNLOAD_MAX_REDIRECTS} redirects from custom downloadBaseURL.`
+         )
+      }
+      // Resolve relative redirects against the current URL, then re-run host
+      // validation so a mirror can't bounce us to a literal internal IP.
+      const next = new URL(location, currentURL)
+      validateBaseURL(next.toString())
+      currentURL = next.toString()
+   }
+
+   if (!response) {
+      throw new Error('Download failed: no response received.')
+   }
+   if (status === 404) {
+      response.message.resume()
+      throw new toolCache.HTTPError(404)
+   }
+   if (status !== 200) {
+      response.message.resume()
+      throw new toolCache.HTTPError(status)
+   }
+
+   const contentLengthHeader = response.message.headers['content-length']
+   const contentLength = Array.isArray(contentLengthHeader)
+      ? contentLengthHeader[0]
+      : contentLengthHeader
+   if (contentLength) {
+      const declared = Number.parseInt(contentLength, 10)
+      if (Number.isFinite(declared) && declared > SECURE_DOWNLOAD_MAX_BYTES) {
+         response.message.resume()
+         throw new Error(
+            `Refusing download: Content-Length ${declared} exceeds cap ${SECURE_DOWNLOAD_MAX_BYTES} bytes.`
+         )
+      }
+   }
+
+   const chunks: Buffer[] = []
+   let received = 0
+   for await (const chunk of response.message as AsyncIterable<Buffer>) {
+      received += chunk.length
+      if (received > SECURE_DOWNLOAD_MAX_BYTES) {
+         response.message.destroy()
+         throw new Error(
+            `Refusing download: response body exceeded cap ${SECURE_DOWNLOAD_MAX_BYTES} bytes.`
+         )
+      }
+      chunks.push(chunk)
+   }
+
+   const tmpDir = process.env['RUNNER_TEMP'] || os.tmpdir()
+   const tmpFile = path.join(tmpDir, `kubectl-${crypto.randomUUID()}`)
+   fs.writeFileSync(tmpFile, Buffer.concat(chunks))
+   return tmpFile
+}
+
+export function validateBaseURL(input: string): URL {
+   let url: URL
+   try {
+      url = new URL(input)
+   } catch {
+      throw new Error(`Invalid downloadBaseURL: "${input}" is not a valid URL.`)
+   }
+
+   if (url.protocol !== 'https:') {
+      throw new Error(
+         `downloadBaseURL must use https://, got "${url.protocol}" in "${input}".`
+      )
+   }
+
+   if (url.username || url.password) {
+      throw new Error(
+         'downloadBaseURL must not contain userinfo (user:pass@host).'
+      )
+   }
+
+   const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, '')
+
+   // Only literal IPs in dangerous ranges are blocked. DNS names (e.g. artifactory.corp.local)
+   // pass through even if they resolve internally to a private IP -- that's the air-gap case.
+   // The SSRF threat is attacker-supplied literal IPs aimed at cloud metadata (169.254.169.254)
+   // or internal services.
+   const ipFamily = net.isIP(host)
+   if (ipFamily === 0) {
+      return url
+   }
+
+   let effectiveHost = host
+   let effectiveFamily = ipFamily
+   if (ipFamily === 6) {
+      // Catch IPv4-mapped (::ffff:a.b.c.d / ::ffff:XXXX:YYYY) and IPv4-compatible
+      // (::a.b.c.d) addresses so e.g. [::ffff:169.254.169.254] can't bypass the v4 rules.
+      const embedded = extractEmbeddedV4(host)
+      if (embedded) {
+         effectiveHost = embedded
+         effectiveFamily = 4
+      }
+   }
+
+   const isLoopback = effectiveHost === '127.0.0.1' || effectiveHost === '::1'
+   const isLoopbackV4Range =
+      effectiveFamily === 4 && /^127\./.test(effectiveHost)
+   const isLinkLocal = effectiveHost.startsWith('169.254.')
+   const isPrivateV4 =
+      /^10\./.test(effectiveHost) ||
+      /^192\.168\./.test(effectiveHost) ||
+      /^172\.(1[6-9]|2\d|3[0-1])\./.test(effectiveHost)
+   const isUniqueLocalV6 = effectiveFamily === 6 && /^f[cd]/.test(effectiveHost)
+   const isLinkLocalV6 =
+      effectiveFamily === 6 && /^fe[89ab]/.test(effectiveHost)
+   const isUnspecified = effectiveHost === '0.0.0.0' || effectiveHost === '::'
+   if (
+      isLoopback ||
+      isLoopbackV4Range ||
+      isLinkLocal ||
+      isPrivateV4 ||
+      isUniqueLocalV6 ||
+      isLinkLocalV6 ||
+      isUnspecified
+   ) {
+      throw new Error(
+         `downloadBaseURL host "${host}" is a literal loopback/link-local/private IP and is blocked.`
+      )
+   }
+
+   return url
+}
+
+// Returns the dotted-quad IPv4 embedded in a v4-mapped (::ffff:a.b.c.d) IPv6
+// address, or null otherwise. Handles both the dotted (::ffff:127.0.0.1) and
+// pure-hex (::ffff:7f00:1) forms. v4-compatible (::a.b.c.d) is deliberately
+// NOT decoded, because that would misclassify ::1 (loopback) as 0.0.0.1.
+function extractEmbeddedV4(v6Host: string): string | null {
+   const dotted = v6Host.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/)
+   if (dotted) return dotted[1]
+
+   // Pure-hex v4-mapped: ::ffff:XXXX:YYYY. Expand the single :: and split into
+   // 16-bit groups; require the first 5 groups == 0 and group[5] == 0xffff.
+   if (!v6Host.includes('::')) return null
+   const [headPart, tailPart] = v6Host.split('::')
+   const head = headPart ? headPart.split(':') : []
+   const tail = tailPart ? tailPart.split(':') : []
+   const fillCount = 8 - head.length - tail.length
+   if (fillCount < 0) return null
+   const groups = [...head, ...Array(fillCount).fill('0'), ...tail]
+   if (groups.length !== 8) return null
+   const ints = groups.map((g) => Number.parseInt(g, 16))
+   if (ints.some((n) => Number.isNaN(n))) return null
+
+   if (!ints.slice(0, 5).every((n) => n === 0)) return null
+   if (ints[5] !== 0xffff) return null
+
+   const a = (ints[6] >> 8) & 0xff
+   const b = ints[6] & 0xff
+   const c = (ints[7] >> 8) & 0xff
+   const d = ints[7] & 0xff
+   return `${a}.${b}.${c}.${d}`
+}
+
+export function validateVersion(version: string): void {
+   if (!/^v?\d+\.\d+\.\d+$/.test(version)) {
+      throw new Error(
+         `Invalid kubectl version: "${version}". Expected a value like "v1.30.0".`
+      )
+   }
+}
+
 export function getKubectlArch(): string {
    const arch = os.arch()
    if (arch === 'x64') {
@@ -11,28 +227,53 @@ export function getKubectlArch(): string {
    return arch
 }
 
-export function getkubectlDownloadURL(version: string, arch: string): string {
+export function getkubectlDownloadURL(
+   version: string,
+   arch: string,
+   baseURL: string = DEFAULT_KUBECTL_BASE_URL
+): string {
+   validateVersion(version)
+   const url = validateBaseURL(baseURL)
+
+   let osDir: string
+   let file: string
    switch (os.type()) {
       case 'Linux':
-         return `https://dl.k8s.io/release/${version}/bin/linux/${arch}/kubectl`
-
+         osDir = 'linux'
+         file = 'kubectl'
+         break
       case 'Darwin':
-         return `https://dl.k8s.io/release/${version}/bin/darwin/${arch}/kubectl`
-
+         osDir = 'darwin'
+         file = 'kubectl'
+         break
       case 'Windows_NT':
       default:
-         return `https://dl.k8s.io/release/${version}/bin/windows/${arch}/kubectl.exe`
+         osDir = 'windows'
+         file = 'kubectl.exe'
+         break
    }
+
+   const basePath = url.pathname.replace(/\/+$/, '')
+   url.pathname = `${basePath}/release/${version}/bin/${osDir}/${arch}/${file}`
+   return url.toString()
 }
 
 export async function getLatestPatchVersion(
    major: string,
-   minor: string
+   minor: string,
+   baseURL: string = DEFAULT_KUBECTL_BASE_URL
 ): Promise<string> {
    const version = `${major}.${minor}`
-   const sourceURL = `https://dl.k8s.io/release/stable-${version}.txt`
+   const url = validateBaseURL(baseURL)
+   const basePath = url.pathname.replace(/\/+$/, '')
+   url.pathname = `${basePath}/release/stable-${version}.txt`
+   const sourceURL = url.toString()
+   const useSecure = !isDefaultBaseURL(baseURL)
+   let downloadPath = ''
    try {
-      const downloadPath = await toolCache.downloadTool(sourceURL)
+      downloadPath = useSecure
+         ? await secureDownload(sourceURL)
+         : await toolCache.downloadTool(sourceURL)
       const latestPatch = fs
          .readFileSync(downloadPath, 'utf8')
          .toString()
@@ -45,6 +286,14 @@ export async function getLatestPatchVersion(
       core.debug(String(error))
       core.warning('GetLatestPatchVersionFailed')
       throw new Error(`Failed to get latest patch version for ${version}`)
+   } finally {
+      if (useSecure && downloadPath) {
+         try {
+            fs.unlinkSync(downloadPath)
+         } catch {
+            /* best-effort cleanup of secureDownload temp file */
+         }
+      }
    }
 }
 

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -1,6 +1,7 @@
 import {vi, describe, test, expect, beforeEach} from 'vitest'
 import * as path from 'path'
 import * as util from 'util'
+import {Readable} from 'stream'
 
 vi.mock('os')
 vi.mock('fs')
@@ -14,32 +15,74 @@ vi.mock('@actions/tool-cache', async (importOriginal) => {
    }
 })
 vi.mock('@actions/core')
+vi.mock('@actions/http-client', () => {
+   const get = vi.fn()
+   return {
+      HttpClient: vi.fn().mockImplementation(function () {
+         return {get}
+      })
+   }
+})
 
 const os = await import('os')
 const fs = await import('fs')
 const toolCache = await import('@actions/tool-cache')
 const core = await import('@actions/core')
+const httpClient = await import('@actions/http-client')
 const run = await import('./run.js')
 const {
+   DEFAULT_KUBECTL_BASE_URL,
    getkubectlDownloadURL,
    getKubectlArch,
    getExecutableExtension,
-   getLatestPatchVersion
+   getLatestPatchVersion,
+   isDefaultBaseURL,
+   validateBaseURL,
+   validateVersion
 } = await import('./helpers.js')
+
+function mockInputs(inputs: Record<string, string>) {
+   vi.mocked(core.getInput).mockImplementation(
+      (name: string) => inputs[name] ?? ''
+   )
+}
+
+function fakeHttpResponse(opts: {
+   status: number
+   body?: string
+   location?: string
+   headers?: Record<string, string>
+}) {
+   const body = Readable.from([Buffer.from(opts.body ?? '')])
+   const message: any = body
+   message.statusCode = opts.status
+   message.headers = {
+      ...(opts.location ? {location: opts.location} : {}),
+      ...(opts.headers ?? {})
+   }
+   return {message, readBody: async () => opts.body ?? ''}
+}
+
+function mockHttpGet(response: ReturnType<typeof fakeHttpResponse>) {
+   const get = vi.fn().mockResolvedValue(response)
+   ;(httpClient.HttpClient as any).mockImplementation(function () {
+      return {get}
+   })
+   return get
+}
 
 describe('Testing all functions in run file.', () => {
    beforeEach(() => {
       vi.clearAllMocks()
    })
+
    test('getExecutableExtension() - return .exe when os is Windows', () => {
       vi.mocked(os.type).mockReturnValue('Windows_NT')
       expect(getExecutableExtension()).toBe('.exe')
-      expect(os.type).toHaveBeenCalled()
    })
    test('getExecutableExtension() - return empty string for non-windows OS', () => {
       vi.mocked(os.type).mockReturnValue('Darwin')
       expect(getExecutableExtension()).toBe('')
-      expect(os.type).toHaveBeenCalled()
    })
    test.each([
       ['arm', 'arm'],
@@ -50,65 +93,175 @@ describe('Testing all functions in run file.', () => {
       (osArch, kubectlArch) => {
          vi.mocked(os.arch).mockReturnValue(osArch as NodeJS.Architecture)
          expect(getKubectlArch()).toBe(kubectlArch)
-         expect(os.arch).toHaveBeenCalled()
       }
    )
+
    test.each([['arm'], ['arm64'], ['amd64']])(
-      'getkubectlDownloadURL() - return the URL to download %s kubectl for Linux',
+      'getkubectlDownloadURL() - default base URL, Linux %s',
       (arch) => {
          vi.mocked(os.type).mockReturnValue('Linux')
-         const kubectlLinuxUrl = util.format(
+         const expected = util.format(
             'https://dl.k8s.io/release/v1.15.0/bin/linux/%s/kubectl',
             arch
          )
-         expect(getkubectlDownloadURL('v1.15.0', arch)).toBe(kubectlLinuxUrl)
-         expect(os.type).toHaveBeenCalled()
+         expect(getkubectlDownloadURL('v1.15.0', arch)).toBe(expected)
       }
    )
    test.each([['arm'], ['arm64'], ['amd64']])(
-      'getkubectlDownloadURL() - return the URL to download %s kubectl for Darwin',
+      'getkubectlDownloadURL() - default base URL, Darwin %s',
       (arch) => {
          vi.mocked(os.type).mockReturnValue('Darwin')
-         const kubectlDarwinUrl = util.format(
+         const expected = util.format(
             'https://dl.k8s.io/release/v1.15.0/bin/darwin/%s/kubectl',
             arch
          )
-         expect(getkubectlDownloadURL('v1.15.0', arch)).toBe(kubectlDarwinUrl)
-         expect(os.type).toHaveBeenCalled()
+         expect(getkubectlDownloadURL('v1.15.0', arch)).toBe(expected)
       }
    )
    test.each([['arm'], ['arm64'], ['amd64']])(
-      'getkubectlDownloadURL() - return the URL to download %s kubectl for Windows',
+      'getkubectlDownloadURL() - default base URL, Windows %s',
       (arch) => {
          vi.mocked(os.type).mockReturnValue('Windows_NT')
-         const kubectlWindowsUrl = util.format(
+         const expected = util.format(
             'https://dl.k8s.io/release/v1.15.0/bin/windows/%s/kubectl.exe',
             arch
          )
-         expect(getkubectlDownloadURL('v1.15.0', arch)).toBe(kubectlWindowsUrl)
-         expect(os.type).toHaveBeenCalled()
+         expect(getkubectlDownloadURL('v1.15.0', arch)).toBe(expected)
       }
    )
-   test('getStableKubectlVersion() - download stable version file, read version and return it', async () => {
+
+   test('getkubectlDownloadURL() - custom base URL', () => {
+      vi.mocked(os.type).mockReturnValue('Linux')
+      expect(
+         getkubectlDownloadURL('v1.15.0', 'amd64', 'https://mirror.example.com')
+      ).toBe(
+         'https://mirror.example.com/release/v1.15.0/bin/linux/amd64/kubectl'
+      )
+   })
+   test('getkubectlDownloadURL() - strips trailing slash from base URL', () => {
+      vi.mocked(os.type).mockReturnValue('Darwin')
+      expect(
+         getkubectlDownloadURL(
+            'v1.15.0',
+            'arm64',
+            'https://mirror.example.com/'
+         )
+      ).toBe(
+         'https://mirror.example.com/release/v1.15.0/bin/darwin/arm64/kubectl'
+      )
+   })
+   test('getkubectlDownloadURL() - base URL with path prefix', () => {
+      vi.mocked(os.type).mockReturnValue('Linux')
+      expect(
+         getkubectlDownloadURL(
+            'v1.30.0',
+            'amd64',
+            'https://mirror.example.com/k8s'
+         )
+      ).toBe(
+         'https://mirror.example.com/k8s/release/v1.30.0/bin/linux/amd64/kubectl'
+      )
+   })
+
+   test.each([
+      ['https://mirror.example.com'],
+      ['https://mirror.example.com:8443'], // non-standard port
+      ['https://172.32.0.1'], // outside RFC1918 172.16/12 range
+      ['https://fcd.example.com'], // DNS label starting with fc/fd is NOT IPv6 ULA
+      ['https://fe89.example.com'] // DNS label starting with fe8-feb is NOT IPv6 link-local
+   ])('validateBaseURL() - accepts %s', (input) => {
+      expect(() => validateBaseURL(input)).not.toThrow()
+   })
+
+   test.each([
+      ['https://dl.k8s.io/', true],
+      ['https://mirror.example.com', false],
+      ['not a url', false]
+   ])('isDefaultBaseURL(%s) === %s', (input, expected) => {
+      expect(isDefaultBaseURL(input as string)).toBe(expected)
+   })
+
+   test.each([
+      ['not a url', /not a valid URL/],
+      ['http://mirror.example.com', /must use https/],
+      ['https://user:pass@mirror.example.com', /userinfo/],
+      ['https://127.0.0.1', /loopback\/link-local\/private/],
+      ['https://[::1]', /loopback\/link-local\/private/], // caught a real bug
+      ['https://169.254.169.254', /loopback\/link-local\/private/], // IMDS
+      ['https://10.0.0.5', /loopback\/link-local\/private/], // RFC1918
+      ['https://192.168.1.1', /loopback\/link-local\/private/], // RFC1918
+      ['https://172.16.0.1', /loopback\/link-local\/private/], // RFC1918 low edge
+      ['https://172.31.255.254', /loopback\/link-local\/private/], // RFC1918 high edge
+      ['https://[fd00::1]', /loopback\/link-local\/private/], // IPv6 ULA
+      ['https://[fc00::1]', /loopback\/link-local\/private/], // IPv6 ULA
+      ['https://[fe80::1]', /loopback\/link-local\/private/], // IPv6 link-local
+      ['https://0.0.0.0', /loopback\/link-local\/private/], // unspecified v4
+      ['https://[::]', /loopback\/link-local\/private/], // unspecified v6
+      // IPv4-mapped IPv6 bypass attempts must be unwrapped and re-checked.
+      ['https://[::ffff:127.0.0.1]', /loopback\/link-local\/private/], // v4-mapped loopback
+      ['https://[::ffff:169.254.169.254]', /loopback\/link-local\/private/], // v4-mapped IMDS
+      ['https://[::ffff:10.0.0.5]', /loopback\/link-local\/private/], // v4-mapped RFC1918
+      ['https://[::ffff:7f00:1]', /loopback\/link-local\/private/] // v4-mapped loopback (pure-hex form)
+   ])('validateBaseURL() - rejects %s', (input, expected) => {
+      expect(() => validateBaseURL(input)).toThrow(expected)
+   })
+
+   test.each([['v1.30.0'], ['1.30.0']])(
+      'validateVersion() - accepts %s',
+      (input) => {
+         expect(() => validateVersion(input)).not.toThrow()
+      }
+   )
+
+   test.each([
+      [''],
+      ['v1.30.0\n'], // trailing newline
+      ['v1.2.3.4'], // extra segment
+      [' v1.30.0'] // leading whitespace
+   ])('validateVersion() - rejects %s', (input) => {
+      expect(() => validateVersion(input)).toThrow(/Invalid kubectl version/)
+   })
+
+   test('getStableKubectlVersion() - default base URL', async () => {
       vi.mocked(toolCache.downloadTool).mockResolvedValue('pathToTool')
       vi.mocked(fs.readFileSync).mockReturnValue('v1.20.4')
       expect(await run.getStableKubectlVersion()).toBe('v1.20.4')
-      expect(toolCache.downloadTool).toHaveBeenCalled()
-      expect(fs.readFileSync).toHaveBeenCalledWith('pathToTool', 'utf8')
+      expect(toolCache.downloadTool).toHaveBeenCalledWith(
+         'https://dl.k8s.io/release/stable.txt'
+      )
    })
-   test('getStableKubectlVersion() - return default v1.15.0 if version read is empty', async () => {
+   test('getStableKubectlVersion() - honours custom base URL (air-gap fix)', async () => {
+      const get = mockHttpGet(fakeHttpResponse({status: 200, body: 'v1.20.4'}))
+      vi.mocked(os.tmpdir).mockReturnValue('/tmp')
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {})
+      vi.mocked(fs.readFileSync).mockReturnValue('v1.20.4')
+      expect(
+         await run.getStableKubectlVersion('https://mirror.example.com')
+      ).toBe('v1.20.4')
+      expect(toolCache.downloadTool).not.toHaveBeenCalled()
+      expect(get).toHaveBeenCalledWith(
+         'https://mirror.example.com/release/stable.txt'
+      )
+   })
+   test('getStableKubectlVersion() - falls back to v1.15.0 on empty file', async () => {
       vi.mocked(toolCache.downloadTool).mockResolvedValue('pathToTool')
       vi.mocked(fs.readFileSync).mockReturnValue('')
       expect(await run.getStableKubectlVersion()).toBe('v1.15.0')
-      expect(toolCache.downloadTool).toHaveBeenCalled()
-      expect(fs.readFileSync).toHaveBeenCalledWith('pathToTool', 'utf8')
    })
-   test('getStableKubectlVersion() - return default v1.15.0 if unable to download file', async () => {
+   test('getStableKubectlVersion() - falls back to v1.15.0 on download failure', async () => {
       vi.mocked(toolCache.downloadTool).mockRejectedValue('Unable to download.')
       expect(await run.getStableKubectlVersion()).toBe('v1.15.0')
-      expect(toolCache.downloadTool).toHaveBeenCalled()
    })
-   test('downloadKubectl() - download kubectl, add it to toolCache and return path to it', async () => {
+   test('getStableKubectlVersion() - custom mirror failure is fatal (no silent fallback)', async () => {
+      // secureDownload rejects; default-URL fallback to v1.15.0 must NOT apply
+      // to a custom mirror, otherwise the real misconfiguration is hidden.
+      mockHttpGet(fakeHttpResponse({status: 500}))
+      await expect(
+         run.getStableKubectlVersion('https://mirror.example.com')
+      ).rejects.toThrow(/Failed to fetch stable\.txt/)
+   })
+
+   test('downloadKubectl() - download and cache, default base URL', async () => {
       vi.mocked(toolCache.find).mockReturnValue('')
       vi.mocked(toolCache.downloadTool).mockResolvedValue('pathToTool')
       vi.mocked(toolCache.cacheFile).mockResolvedValue('pathToCachedTool')
@@ -117,32 +270,28 @@ describe('Testing all functions in run file.', () => {
       expect(await run.downloadKubectl('v1.15.0')).toBe(
          path.join('pathToCachedTool', 'kubectl.exe')
       )
-      expect(toolCache.find).toHaveBeenCalledWith('kubectl', 'v1.15.0')
-      expect(toolCache.downloadTool).toHaveBeenCalled()
-      expect(toolCache.cacheFile).toHaveBeenCalled()
-      expect(os.type).toHaveBeenCalled()
-      expect(fs.chmodSync).toHaveBeenCalledWith(
-         path.join('pathToCachedTool', 'kubectl.exe'),
-         '775'
+      expect(toolCache.downloadTool).toHaveBeenCalledWith(
+         'https://dl.k8s.io/release/v1.15.0/bin/windows/amd64/kubectl.exe'
       )
    })
-   test('downloadKubectl() - throw DownloadKubectlFailed error when unable to download kubectl', async () => {
-      vi.mocked(toolCache.find).mockReturnValue('')
-      vi.mocked(toolCache.downloadTool).mockRejectedValue(
-         'Unable to download kubectl.'
+   test('downloadKubectl() - rejects invalid version (path traversal)', async () => {
+      await expect(run.downloadKubectl('../etc')).rejects.toThrow(
+         /Invalid kubectl version/
       )
+   })
+   test('downloadKubectl() - throws DownloadKubectlFailed on generic error', async () => {
+      vi.mocked(toolCache.find).mockReturnValue('')
+      vi.mocked(toolCache.downloadTool).mockRejectedValue('boom')
       await expect(run.downloadKubectl('v1.15.0')).rejects.toThrow(
          'DownloadKubectlFailed'
       )
-      expect(toolCache.find).toHaveBeenCalledWith('kubectl', 'v1.15.0')
-      expect(toolCache.downloadTool).toHaveBeenCalled()
    })
-   test('downloadKubectl() - throw kubectl not found error when receive 404 response', async () => {
+   test('downloadKubectl() - 404 maps to "not found" message', async () => {
       const kubectlVersion = 'v1.15.0'
-      const arch = 'arm128'
+      const arch = 'arm64'
       vi.mocked(os.arch).mockReturnValue(arch as NodeJS.Architecture)
       vi.mocked(toolCache.find).mockReturnValue('')
-      vi.mocked(toolCache.downloadTool).mockImplementation((_) => {
+      vi.mocked(toolCache.downloadTool).mockImplementation(() => {
          throw new toolCache.HTTPError(404)
       })
       await expect(run.downloadKubectl(kubectlVersion)).rejects.toThrow(
@@ -152,114 +301,337 @@ describe('Testing all functions in run file.', () => {
             arch
          )
       )
-      expect(os.arch).toHaveBeenCalled()
-      expect(toolCache.find).toHaveBeenCalledWith('kubectl', kubectlVersion)
-      expect(toolCache.downloadTool).toHaveBeenCalled()
    })
-   test('downloadKubectl() - return path to existing cache of kubectl', async () => {
-      vi.mocked(core.getInput).mockImplementation(() => 'v1.15.5')
+   test('downloadKubectl() - returns existing cache without redownloading', async () => {
       vi.mocked(toolCache.find).mockReturnValue('pathToCachedTool')
       vi.mocked(os.type).mockReturnValue('Windows_NT')
       vi.mocked(fs.chmodSync).mockImplementation(() => {})
       expect(await run.downloadKubectl('v1.15.0')).toBe(
          path.join('pathToCachedTool', 'kubectl.exe')
       )
-      expect(toolCache.find).toHaveBeenCalledWith('kubectl', 'v1.15.0')
-      expect(os.type).toHaveBeenCalled()
-      expect(fs.chmodSync).toHaveBeenCalledWith(
-         path.join('pathToCachedTool', 'kubectl.exe'),
-         '775'
+      expect(toolCache.downloadTool).not.toHaveBeenCalled()
+   })
+
+   test('downloadKubectl() - rejects malformed checksum input', async () => {
+      vi.mocked(toolCache.find).mockReturnValue('')
+      vi.mocked(toolCache.downloadTool).mockResolvedValue('pathToTool')
+      vi.mocked(os.type).mockReturnValue('Linux')
+      vi.mocked(os.arch).mockReturnValue('x64')
+      vi.mocked(fs.readFileSync).mockReturnValue(Buffer.from('hi') as never)
+      await expect(
+         run.downloadKubectl('v1.15.0', DEFAULT_KUBECTL_BASE_URL, 'not-a-hash')
+      ).rejects.toThrow(/Invalid checksum input/)
+   })
+   test('downloadKubectl() - rejects checksum mismatch', async () => {
+      vi.mocked(toolCache.find).mockReturnValue('')
+      vi.mocked(toolCache.downloadTool).mockResolvedValue('pathToTool')
+      vi.mocked(os.type).mockReturnValue('Linux')
+      vi.mocked(os.arch).mockReturnValue('x64')
+      vi.mocked(fs.readFileSync).mockReturnValue(Buffer.from('hi') as never)
+      const wrong = 'a'.repeat(64)
+      await expect(
+         run.downloadKubectl('v1.15.0', DEFAULT_KUBECTL_BASE_URL, wrong)
+      ).rejects.toThrow(/Checksum mismatch/)
+   })
+   test('downloadKubectl() - accepts matching checksum', async () => {
+      vi.mocked(toolCache.find).mockReturnValue('')
+      vi.mocked(toolCache.downloadTool).mockResolvedValue('pathToTool')
+      vi.mocked(toolCache.cacheFile).mockResolvedValue('pathToCachedTool')
+      vi.mocked(os.type).mockReturnValue('Linux')
+      vi.mocked(os.arch).mockReturnValue('x64')
+      vi.mocked(fs.chmodSync).mockImplementation(() => {})
+      // sha256('hi') = 8f434346648f6b96df89dda901c5176b10a6d83961dd3c1ac88b59b2dc327aa4
+      vi.mocked(fs.readFileSync).mockReturnValue(Buffer.from('hi') as never)
+      const correct =
+         '8f434346648f6b96df89dda901c5176b10a6d83961dd3c1ac88b59b2dc327aa4'
+      await expect(
+         run.downloadKubectl('v1.15.0', DEFAULT_KUBECTL_BASE_URL, correct)
+      ).resolves.toBe(path.join('pathToCachedTool', 'kubectl'))
+   })
+
+   test('downloadKubectl() - custom mirror: rejects 3xx redirect to non-https / blocked host (SSRF guard)', async () => {
+      vi.mocked(toolCache.find).mockReturnValue('')
+      vi.mocked(os.type).mockReturnValue('Linux')
+      vi.mocked(os.arch).mockReturnValue('x64')
+      mockHttpGet(
+         fakeHttpResponse({
+            status: 302,
+            location: 'http://169.254.169.254/latest/meta-data/'
+         })
+      )
+      // Redirect target fails baseURL re-validation (http://, and literal link-local IP),
+      // so the underlying validation error must surface (not a generic "DownloadKubectlFailed").
+      await expect(
+         run.downloadKubectl('v1.15.0', 'https://mirror.example.com')
+      ).rejects.toThrow(/must use https|loopback\/link-local\/private/)
+      expect(toolCache.downloadTool).not.toHaveBeenCalled()
+   })
+
+   test('downloadKubectl() - custom mirror: non-200/non-404 (500) fails', async () => {
+      vi.mocked(toolCache.find).mockReturnValue('')
+      vi.mocked(os.type).mockReturnValue('Linux')
+      vi.mocked(os.arch).mockReturnValue('x64')
+      mockHttpGet(fakeHttpResponse({status: 500}))
+      // 500 surfaces as the underlying HTTPError so users get a useful failure mode.
+      await expect(
+         run.downloadKubectl('v1.15.0', 'https://mirror.example.com')
+      ).rejects.toThrow(/500/)
+      expect(toolCache.downloadTool).not.toHaveBeenCalled()
+   })
+
+   test('downloadKubectl() - custom mirror: 404 maps to "not found"', async () => {
+      vi.mocked(toolCache.find).mockReturnValue('')
+      vi.mocked(os.type).mockReturnValue('Linux')
+      const arch = 'amd64'
+      vi.mocked(os.arch).mockReturnValue('x64')
+      mockHttpGet(fakeHttpResponse({status: 404}))
+      await expect(
+         run.downloadKubectl('v1.15.0', 'https://mirror.example.com')
+      ).rejects.toThrow(
+         util.format("Kubectl '%s' for '%s' arch not found.", 'v1.15.0', arch)
       )
       expect(toolCache.downloadTool).not.toHaveBeenCalled()
    })
-   test('getLatestPatchVersion() - download and return latest patch version', async () => {
+
+   test('downloadKubectl() - custom mirror: 200 streams body to temp file and caches', async () => {
+      vi.mocked(toolCache.find).mockReturnValue('')
+      vi.mocked(toolCache.cacheFile).mockResolvedValue('pathToCachedTool')
+      vi.mocked(os.type).mockReturnValue('Linux')
+      vi.mocked(os.arch).mockReturnValue('x64')
+      vi.mocked(os.tmpdir).mockReturnValue('/tmp')
+      vi.mocked(fs.chmodSync).mockImplementation(() => {})
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {})
+      mockHttpGet(fakeHttpResponse({status: 200, body: 'kubectl-bytes'}))
+
+      await expect(
+         run.downloadKubectl('v1.15.0', 'https://mirror.example.com')
+      ).resolves.toBe(path.join('pathToCachedTool', 'kubectl'))
+      expect(toolCache.downloadTool).not.toHaveBeenCalled()
+      expect(toolCache.cacheFile).toHaveBeenCalled()
+      // Assert the body actually streamed to disk (not an empty write).
+      const [writePath, writeContent] = vi.mocked(fs.writeFileSync).mock
+         .calls[0]
+      expect(String(writePath)).toMatch(/[/\\]kubectl-[0-9a-f-]+$/)
+      expect((writeContent as Buffer).toString()).toBe('kubectl-bytes')
+   })
+
+   test('downloadKubectl() - custom mirror: rejects oversized Content-Length up front', async () => {
+      vi.mocked(toolCache.find).mockReturnValue('')
+      vi.mocked(os.type).mockReturnValue('Linux')
+      vi.mocked(os.arch).mockReturnValue('x64')
+      mockHttpGet(
+         fakeHttpResponse({
+            status: 200,
+            body: 'unused',
+            headers: {'content-length': String(1024 * 1024 * 1024)} // 1 GiB
+         })
+      )
+      await expect(
+         run.downloadKubectl('v1.15.0', 'https://mirror.example.com')
+      ).rejects.toThrow(/Content-Length/)
+      expect(toolCache.cacheFile).not.toHaveBeenCalled()
+   })
+
+   test('downloadKubectl() - cache key is scoped per non-default baseURL', async () => {
+      // Default URL must use the bare version as the cache key (existing user caches stay valid).
+      vi.mocked(toolCache.find).mockReturnValue('pathToCachedTool')
+      vi.mocked(os.type).mockReturnValue('Linux')
+      vi.mocked(fs.chmodSync).mockImplementation(() => {})
+      await run.downloadKubectl('v1.15.0', DEFAULT_KUBECTL_BASE_URL)
+      expect(toolCache.find).toHaveBeenLastCalledWith('kubectl', 'v1.15.0')
+
+      // Custom mirror must derive a distinct, deterministic suffixed key.
+      await run.downloadKubectl('v1.15.0', 'https://mirror.example.com')
+      const customKey = vi.mocked(toolCache.find).mock.lastCall?.[1]
+      expect(customKey).toMatch(/^v1\.15\.0-[0-9a-f]{12}$/)
+      expect(customKey).not.toBe('v1.15.0')
+
+      // A different mirror must produce a different key (otherwise cache poisoning is back).
+      await run.downloadKubectl('v1.15.0', 'https://other-mirror.example.com')
+      const otherKey = vi.mocked(toolCache.find).mock.lastCall?.[1]
+      expect(otherKey).not.toBe(customKey)
+   })
+
+   test('downloadKubectl() - custom mirror: temp file is unlinked after caching', async () => {
+      vi.mocked(toolCache.find).mockReturnValue('')
+      vi.mocked(toolCache.cacheFile).mockResolvedValue('pathToCachedTool')
+      vi.mocked(os.type).mockReturnValue('Linux')
+      vi.mocked(os.arch).mockReturnValue('x64')
+      vi.mocked(os.tmpdir).mockReturnValue('/tmp')
+      vi.mocked(fs.chmodSync).mockImplementation(() => {})
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {})
+      vi.mocked(fs.unlinkSync).mockImplementation(() => {})
+      mockHttpGet(fakeHttpResponse({status: 200, body: 'kubectl-bytes'}))
+
+      await run.downloadKubectl('v1.15.0', 'https://mirror.example.com')
+
+      // The same temp path written by secureDownload must be unlinked afterwards.
+      const writtenPath = String(vi.mocked(fs.writeFileSync).mock.calls[0][0])
+      expect(writtenPath).toMatch(/[/\\]kubectl-[0-9a-f-]+$/)
+      expect(fs.unlinkSync).toHaveBeenCalledWith(writtenPath)
+   })
+
+   test('downloadKubectl() - custom mirror: temp file is unlinked even on checksum mismatch', async () => {
+      vi.mocked(toolCache.find).mockReturnValue('')
+      vi.mocked(os.type).mockReturnValue('Linux')
+      vi.mocked(os.arch).mockReturnValue('x64')
+      vi.mocked(os.tmpdir).mockReturnValue('/tmp')
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {})
+      vi.mocked(fs.unlinkSync).mockImplementation(() => {})
+      vi.mocked(fs.readFileSync).mockReturnValue(Buffer.from('hi') as never)
+      mockHttpGet(fakeHttpResponse({status: 200, body: 'hi'}))
+
+      const wrong = 'a'.repeat(64)
+      await expect(
+         run.downloadKubectl('v1.15.0', 'https://mirror.example.com', wrong)
+      ).rejects.toThrow(/Checksum mismatch/)
+      expect(fs.unlinkSync).toHaveBeenCalled()
+   })
+
+   test('getLatestPatchVersion() - default base URL', async () => {
       vi.mocked(toolCache.downloadTool).mockResolvedValue('pathToTool')
       vi.mocked(fs.readFileSync).mockReturnValue('v1.27.15')
-
-      const result = await getLatestPatchVersion('1', '27')
-
-      expect(result).toBe('v1.27.15')
+      expect(await getLatestPatchVersion('1', '27')).toBe('v1.27.15')
       expect(toolCache.downloadTool).toHaveBeenCalledWith(
          'https://dl.k8s.io/release/stable-1.27.txt'
       )
    })
-
-   test('getLatestPatchVersion() - throw error when patch version is empty', async () => {
+   test('getLatestPatchVersion() - honours custom base URL', async () => {
+      const get = mockHttpGet(fakeHttpResponse({status: 200, body: 'v1.27.15'}))
+      vi.mocked(os.tmpdir).mockReturnValue('/tmp')
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {})
+      vi.mocked(fs.readFileSync).mockReturnValue('v1.27.15')
+      expect(
+         await getLatestPatchVersion('1', '27', 'https://mirror.example.com')
+      ).toBe('v1.27.15')
+      expect(toolCache.downloadTool).not.toHaveBeenCalled()
+      expect(get).toHaveBeenCalledWith(
+         'https://mirror.example.com/release/stable-1.27.txt'
+      )
+   })
+   test('getLatestPatchVersion() - throws on empty file', async () => {
       vi.mocked(toolCache.downloadTool).mockResolvedValue('pathToTool')
       vi.mocked(fs.readFileSync).mockReturnValue('')
-
+      await expect(getLatestPatchVersion('1', '27')).rejects.toThrow(
+         'Failed to get latest patch version for 1.27'
+      )
+   })
+   test('getLatestPatchVersion() - throws on download failure', async () => {
+      vi.mocked(toolCache.downloadTool).mockRejectedValue(new Error('Network'))
       await expect(getLatestPatchVersion('1', '27')).rejects.toThrow(
          'Failed to get latest patch version for 1.27'
       )
    })
 
-   test('getLatestPatchVersion() - throw error when download fails', async () => {
-      vi.mocked(toolCache.downloadTool).mockRejectedValue(
-         new Error('Network error')
-      )
-
-      await expect(getLatestPatchVersion('1', '27')).rejects.toThrow(
-         'Failed to get latest patch version for 1.27'
-      )
-   })
-   test('resolveKubectlVersion() - expands major.minor to latest patch', async () => {
+   test('resolveKubectlVersion() - expands major.minor', async () => {
       vi.mocked(toolCache.downloadTool).mockResolvedValue('pathToTool')
       vi.mocked(fs.readFileSync).mockReturnValue('v1.27.15')
-
-      const result = await run.resolveKubectlVersion('1.27')
-      expect(result).toBe('v1.27.15')
+      expect(await run.resolveKubectlVersion('1.27')).toBe('v1.27.15')
    })
-
    test('resolveKubectlVersion() - returns full version unchanged', async () => {
-      const result = await run.resolveKubectlVersion('v1.27.15')
-      expect(result).toBe('v1.27.15')
+      expect(await run.resolveKubectlVersion('v1.27.15')).toBe('v1.27.15')
    })
-   test('resolveKubectlVersion() - adds v prefix to full version', async () => {
-      const result = await run.resolveKubectlVersion('1.27.15')
-      expect(result).toBe('v1.27.15')
+   test('resolveKubectlVersion() - adds v prefix', async () => {
+      expect(await run.resolveKubectlVersion('1.27.15')).toBe('v1.27.15')
    })
-   test('resolveKubectlVersion() - expands v-prefixed major.minor to latest patch', async () => {
-      vi.mocked(toolCache.downloadTool).mockResolvedValue('pathToTool')
-      vi.mocked(fs.readFileSync).mockReturnValue('v1.27.15')
 
-      const result = await run.resolveKubectlVersion('v1.27')
-      expect(result).toBe('v1.27.15')
-   })
-   test('run() - download specified version and set output', async () => {
-      vi.mocked(core.getInput).mockReturnValue('v1.15.5')
+   test('run() - reads version, downloadBaseURL, checksum inputs; defaults applied', async () => {
+      mockInputs({version: 'v1.15.5'})
       vi.mocked(toolCache.find).mockReturnValue('pathToCachedTool')
       vi.mocked(os.type).mockReturnValue('Windows_NT')
       vi.mocked(fs.chmodSync).mockImplementation()
       vi.mocked(core.addPath).mockImplementation()
-      vi.spyOn(console, 'log').mockImplementation()
       vi.mocked(core.setOutput).mockImplementation()
-      expect(await run.run()).toBeUndefined()
+
+      await expect(run.run()).resolves.toBeUndefined()
       expect(core.getInput).toHaveBeenCalledWith('version', {required: true})
-      expect(core.addPath).toHaveBeenCalledWith('pathToCachedTool')
+      expect(core.getInput).toHaveBeenCalledWith('downloadBaseURL', {
+         required: false
+      })
+      expect(core.getInput).toHaveBeenCalledWith('checksum', {required: false})
+      // Default base URL: no audit notice should fire.
+      expect(core.notice).not.toHaveBeenCalled()
       expect(core.setOutput).toHaveBeenCalledWith(
          'kubectl-path',
          path.join('pathToCachedTool', 'kubectl.exe')
       )
    })
-   test('run() - get latest version, download it and set output', async () => {
-      vi.mocked(core.getInput).mockReturnValue('latest')
-      vi.mocked(toolCache.downloadTool).mockResolvedValue('pathToTool')
+
+   test('run() - latest + custom mirror routes stable.txt through the mirror', async () => {
+      mockInputs({
+         version: 'latest',
+         downloadBaseURL: 'https://mirror.example.com'
+      })
+      const get = mockHttpGet(fakeHttpResponse({status: 200, body: 'v1.20.4'}))
+      vi.mocked(os.tmpdir).mockReturnValue('/tmp')
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {})
       vi.mocked(fs.readFileSync).mockReturnValue('v1.20.4')
       vi.mocked(toolCache.find).mockReturnValue('pathToCachedTool')
       vi.mocked(os.type).mockReturnValue('Windows_NT')
       vi.mocked(fs.chmodSync).mockImplementation()
       vi.mocked(core.addPath).mockImplementation()
-      vi.spyOn(console, 'log').mockImplementation()
       vi.mocked(core.setOutput).mockImplementation()
-      expect(await run.run()).toBeUndefined()
+
+      await expect(run.run()).resolves.toBeUndefined()
+      // The fix: stable.txt comes from the custom mirror via secureDownload,
+      // not toolCache.downloadTool (which would follow redirects).
+      expect(get).toHaveBeenCalledWith(
+         'https://mirror.example.com/release/stable.txt'
+      )
+      expect(toolCache.downloadTool).not.toHaveBeenCalled()
+      // Audit notice fires for any non-default base URL.
+      expect(core.notice).toHaveBeenCalledWith(
+         expect.stringContaining('https://mirror.example.com')
+      )
+      // No checksum + custom mirror => loud warning.
+      expect(core.warning).toHaveBeenCalledWith(
+         expect.stringContaining('checksum')
+      )
+   })
+
+   test('run() - empty/whitespace downloadBaseURL falls back to default', async () => {
+      mockInputs({version: 'v1.15.5', downloadBaseURL: '   '})
+      vi.mocked(toolCache.find).mockReturnValue('') // force a real download path
+      vi.mocked(toolCache.downloadTool).mockResolvedValue('pathToTool')
+      vi.mocked(toolCache.cacheFile).mockResolvedValue('pathToCachedTool')
+      vi.mocked(os.type).mockReturnValue('Linux')
+      vi.mocked(os.arch).mockReturnValue('x64')
+      vi.mocked(fs.chmodSync).mockImplementation()
+      vi.mocked(core.addPath).mockImplementation()
+      vi.mocked(core.setOutput).mockImplementation()
+
+      await expect(run.run()).resolves.toBeUndefined()
+      // Whitespace must collapse to the default URL, which uses toolCache (not secureDownload).
       expect(toolCache.downloadTool).toHaveBeenCalledWith(
-         'https://dl.k8s.io/release/stable.txt'
+         expect.stringContaining('https://dl.k8s.io/')
       )
-      expect(core.getInput).toHaveBeenCalledWith('version', {required: true})
-      expect(core.addPath).toHaveBeenCalledWith('pathToCachedTool')
-      expect(core.setOutput).toHaveBeenCalledWith(
-         'kubectl-path',
-         path.join('pathToCachedTool', 'kubectl.exe')
-      )
+      expect(core.notice).not.toHaveBeenCalled()
+   })
+
+   test('run() - invalid downloadBaseURL (http) fails fast', async () => {
+      mockInputs({version: 'v1.15.5', downloadBaseURL: 'http://insecure'})
+      await expect(run.run()).rejects.toThrow(/must use https/)
+   })
+
+   test('run() - uppercase checksum input is normalized and accepted', async () => {
+      // sha256('hi') = 8f43...aa4 — supplied uppercase to prove run() lowercases it
+      // before validateChecksum's strict /^[a-f0-9]{64}$/ regex sees it.
+      const correctLower =
+         '8f434346648f6b96df89dda901c5176b10a6d83961dd3c1ac88b59b2dc327aa4'
+      mockInputs({
+         version: 'v1.15.5',
+         checksum: correctLower.toUpperCase()
+      })
+      vi.mocked(toolCache.find).mockReturnValue('')
+      vi.mocked(toolCache.downloadTool).mockResolvedValue('pathToTool')
+      vi.mocked(toolCache.cacheFile).mockResolvedValue('pathToCachedTool')
+      vi.mocked(os.type).mockReturnValue('Linux')
+      vi.mocked(os.arch).mockReturnValue('x64')
+      vi.mocked(fs.readFileSync).mockReturnValue(Buffer.from('hi') as never)
+      vi.mocked(fs.chmodSync).mockImplementation()
+      vi.mocked(core.addPath).mockImplementation()
+      vi.mocked(core.setOutput).mockImplementation()
+
+      await expect(run.run()).resolves.toBeUndefined()
    })
 })

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,27 +1,58 @@
 import * as path from 'path'
 import * as util from 'util'
 import * as fs from 'fs'
+import * as crypto from 'crypto'
 import * as toolCache from '@actions/tool-cache'
 import * as core from '@actions/core'
 import {
+   DEFAULT_KUBECTL_BASE_URL,
    getkubectlDownloadURL,
    getKubectlArch,
    getExecutableExtension,
-   getLatestPatchVersion
+   getLatestPatchVersion,
+   isDefaultBaseURL,
+   normalizeBaseURL,
+   secureDownload,
+   validateBaseURL,
+   validateVersion
 } from './helpers.js'
 
 const kubectlToolName = 'kubectl'
 const stableKubectlVersion = 'v1.15.0'
-const stableVersionUrl = 'https://dl.k8s.io/release/stable.txt'
 
 export async function run() {
    let version = core.getInput('version', {required: true})
-   if (version.toLocaleLowerCase() === 'latest') {
-      version = await getStableKubectlVersion()
-   } else {
-      version = await resolveKubectlVersion(version)
+
+   const rawBaseURL = core.getInput('downloadBaseURL', {required: false}).trim()
+   const downloadBaseURL = rawBaseURL || DEFAULT_KUBECTL_BASE_URL
+   validateBaseURL(downloadBaseURL)
+
+   const expectedChecksum = core
+      .getInput('checksum', {required: false})
+      .trim()
+      .toLowerCase()
+
+   if (!isDefaultBaseURL(downloadBaseURL)) {
+      core.notice(
+         `kubectl will be downloaded from a custom mirror: ${downloadBaseURL}`
+      )
+      if (!expectedChecksum) {
+         core.warning(
+            'Custom downloadBaseURL set without a `checksum` input; the downloaded binary will NOT be integrity-verified. On self-hosted runners, a single tampered download would be cached and reused across jobs. Set the `checksum` input to enable SHA-256 verification on every run.'
+         )
+      }
    }
-   const cachedPath = await downloadKubectl(version)
+
+   if (version.toLocaleLowerCase() === 'latest') {
+      version = await getStableKubectlVersion(downloadBaseURL)
+   } else {
+      version = await resolveKubectlVersion(version, downloadBaseURL)
+   }
+   const cachedPath = await downloadKubectl(
+      version,
+      downloadBaseURL,
+      expectedChecksum
+   )
 
    core.addPath(path.dirname(cachedPath))
 
@@ -31,32 +62,72 @@ export async function run() {
    core.setOutput('kubectl-path', cachedPath)
 }
 
-export async function getStableKubectlVersion(): Promise<string> {
-   return toolCache.downloadTool(stableVersionUrl).then(
-      (downloadPath) => {
-         let version = fs.readFileSync(downloadPath, 'utf8').toString().trim()
-         if (!version) {
-            version = stableKubectlVersion
-         }
-         return version
-      },
-      (error) => {
-         core.debug(error)
-         core.warning('GetStableVersionFailed')
-         return stableKubectlVersion
+export async function getStableKubectlVersion(
+   baseURL: string = DEFAULT_KUBECTL_BASE_URL
+): Promise<string> {
+   const url = validateBaseURL(baseURL)
+   const basePath = url.pathname.replace(/\/+$/, '')
+   url.pathname = `${basePath}/release/stable.txt`
+   const stableVersionUrl = url.toString()
+   const useSecure = !isDefaultBaseURL(baseURL)
+
+   let downloadPath = ''
+   try {
+      downloadPath = useSecure
+         ? await secureDownload(stableVersionUrl)
+         : await toolCache.downloadTool(stableVersionUrl)
+      let version = fs.readFileSync(downloadPath, 'utf8').toString().trim()
+      if (!version) {
+         version = stableKubectlVersion
       }
-   )
+      return version
+   } catch (error) {
+      core.debug(String(error))
+      if (useSecure) {
+         throw new Error(
+            `Failed to fetch stable.txt from custom downloadBaseURL "${baseURL}".`
+         )
+      }
+      core.warning('GetStableVersionFailed')
+      return stableKubectlVersion
+   } finally {
+      if (useSecure && downloadPath) {
+         try {
+            fs.unlinkSync(downloadPath)
+         } catch {
+            /* best-effort cleanup of secureDownload temp file */
+         }
+      }
+   }
 }
 
-export async function downloadKubectl(version: string): Promise<string> {
-   let cachedToolpath = toolCache.find(kubectlToolName, version)
+export async function downloadKubectl(
+   version: string,
+   baseURL: string = DEFAULT_KUBECTL_BASE_URL,
+   expectedChecksum: string = ''
+): Promise<string> {
+   validateVersion(version)
+
+   // Scope the cache key per mirror so a binary cached from one source isn't silently reused for another.
+   const cacheKey = isDefaultBaseURL(baseURL)
+      ? version
+      : `${version}-${crypto
+           .createHash('sha256')
+           .update(normalizeBaseURL(baseURL))
+           .digest('hex')
+           .slice(0, 12)}`
+
+   let cachedToolpath = toolCache.find(kubectlToolName, cacheKey)
    let kubectlDownloadPath = ''
    const arch = getKubectlArch()
    if (!cachedToolpath) {
+      const downloadURL = getkubectlDownloadURL(version, arch, baseURL)
       try {
-         kubectlDownloadPath = await toolCache.downloadTool(
-            getkubectlDownloadURL(version, arch)
-         )
+         if (isDefaultBaseURL(baseURL)) {
+            kubectlDownloadPath = await toolCache.downloadTool(downloadURL)
+         } else {
+            kubectlDownloadPath = await secureDownload(downloadURL)
+         }
       } catch (exception) {
          if (
             exception instanceof toolCache.HTTPError &&
@@ -69,28 +140,71 @@ export async function downloadKubectl(version: string): Promise<string> {
                   arch
                )
             )
-         } else {
-            throw new Error('DownloadKubectlFailed')
          }
+         // Preserve the original error so custom-mirror failures (e.g. 500, TLS,
+         // rejected redirect) surface a useful message instead of "DownloadKubectlFailed".
+         throw exception instanceof Error
+            ? exception
+            : new Error(`DownloadKubectlFailed: ${String(exception)}`)
       }
 
-      cachedToolpath = await toolCache.cacheFile(
-         kubectlDownloadPath,
-         kubectlToolName + getExecutableExtension(),
-         kubectlToolName,
-         version
-      )
+      try {
+         if (expectedChecksum) {
+            verifyChecksum(kubectlDownloadPath, expectedChecksum)
+         }
+
+         cachedToolpath = await toolCache.cacheFile(
+            kubectlDownloadPath,
+            kubectlToolName + getExecutableExtension(),
+            kubectlToolName,
+            cacheKey
+         )
+      } finally {
+         if (!isDefaultBaseURL(baseURL) && kubectlDownloadPath) {
+            try {
+               fs.unlinkSync(kubectlDownloadPath)
+            } catch {
+               /* best-effort cleanup of secureDownload temp file */
+            }
+         }
+      }
    }
 
    const kubectlPath = path.join(
       cachedToolpath,
       kubectlToolName + getExecutableExtension()
    )
+
+   // Re-verify on every run so cached binaries from prior runs are also checked.
+   if (expectedChecksum) {
+      verifyChecksum(kubectlPath, expectedChecksum)
+   }
+
    fs.chmodSync(kubectlPath, '775')
    return kubectlPath
 }
 
-export async function resolveKubectlVersion(version: string): Promise<string> {
+function verifyChecksum(filePath: string, expected: string): void {
+   if (!/^[a-f0-9]{64}$/.test(expected)) {
+      throw new Error(
+         `Invalid checksum input: expected a 64-character hex SHA256 string.`
+      )
+   }
+   const actual = crypto
+      .createHash('sha256')
+      .update(fs.readFileSync(filePath))
+      .digest('hex')
+   if (actual !== expected) {
+      throw new Error(
+         `Checksum mismatch for downloaded kubectl. Expected ${expected}, got ${actual}.`
+      )
+   }
+}
+
+export async function resolveKubectlVersion(
+   version: string,
+   baseURL: string = DEFAULT_KUBECTL_BASE_URL
+): Promise<string> {
    const cleanedVersion = version.trim()
    const versionMatch = cleanedVersion.match(
       /^v?(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?$/
@@ -111,6 +225,6 @@ export async function resolveKubectlVersion(version: string): Promise<string> {
          : `v${cleanedVersion}`
    }
 
-   // Patch version is missing, fetch the latest
-   return await getLatestPatchVersion(major, minor)
+   // Patch version is missing, fetch the latest from the (possibly custom) mirror.
+   return await getLatestPatchVersion(major, minor, baseURL)
 }


### PR DESCRIPTION
Add downloadBaseURL and checksum inputs (closes #206)

Supports private kubectl mirrors (air-gapped / enterprise) with
optional SHA256 verification. Default base URL is unchanged.

Security: https-only, blocks loopback/link-local/RFC1918 hosts,
rejects redirects on custom mirrors, validates version
format before any URL/path use.